### PR TITLE
[API-7551] fix CA initialization stuck on large spotinst cluster

### DIFF
--- a/cluster-autoscaler/cloudprovider/spotinst/spotinst_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/spotinst/spotinst_cloud_provider_test.go
@@ -235,6 +235,9 @@ func TestNodeGroupForNode(t *testing.T) {
 	provider := testCloudProvider(t, testCloudManager(t))
 	err := provider.manager.addNodeGroup("1:5:sig-test")
 	assert.NoError(t, err)
+	
+	provider.Refresh()
+	
 	group, err := provider.NodeGroupForNode(node)
 
 	assert.NoError(t, err)
@@ -315,6 +318,8 @@ func TestBelongs(t *testing.T) {
 	provider := testCloudProvider(t, testCloudManager(t))
 	err := provider.manager.addNodeGroup("1:5:sig-test")
 	assert.NoError(t, err)
+	
+	provider.Refresh()
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -339,6 +344,8 @@ func TestDeleteNodes(t *testing.T) {
 	err := provider.manager.addNodeGroup("1:5:sig-test")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.manager.groups), 1)
+	
+	provider.Refresh()
 
 	cloud := provider.manager.groupService.CloudProviderAWS().(*awsServiceMock)
 	cloud.On("Detach", context.Background(), &aws.DetachGroupInput{

--- a/cluster-autoscaler/cloudprovider/spotinst/spotinst_manager.go
+++ b/cluster-autoscaler/cloudprovider/spotinst/spotinst_manager.go
@@ -232,14 +232,6 @@ func (mgr *CloudManager) GetGroupForInstance(instanceID string) (*Group, error) 
 		return group, nil
 	}
 
-	if err := mgr.forceRefresh(); err != nil {
-		return nil, err
-	}
-
-	if group, ok := mgr.cache[instanceID]; ok {
-		return group, nil
-	}
-
 	klog.Warningf("Instance `%s` does not belong to any managed group", instanceID)
 	return nil, nil
 }

--- a/cluster-autoscaler/cloudprovider/spotinst/spotinst_manager.go
+++ b/cluster-autoscaler/cloudprovider/spotinst/spotinst_manager.go
@@ -232,7 +232,7 @@ func (mgr *CloudManager) GetGroupForInstance(instanceID string) (*Group, error) 
 		return group, nil
 	}
 
-	klog.Warningf("Instance `%s` does not belong to any managed group", instanceID)
+	klog.V(8).Infof("Instance `%s` does not belong to any managed group", instanceID)
 	return nil, nil
 }
 
@@ -327,7 +327,7 @@ func (mgr *CloudManager) refreshGroupNodes(grp *Group) error {
 	for _, instance := range status.Instances {
 		if instance.ID != nil {
 			instanceID := spotinst.StringValue(instance.ID)
-			klog.Infof("Managing AWS instance with ID %s in group %s", instanceID, grp.Id())
+			klog.V(8).Infof("Managing AWS instance with ID %s in group %s", instanceID, grp.Id())
 			mgr.cache[instanceID] = grp
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/spotinst/spotinst_node_group.go
+++ b/cluster-autoscaler/cloudprovider/spotinst/spotinst_node_group.go
@@ -222,6 +222,6 @@ func extractInstanceId(providerID string) (string, error) {
 	parts := strings.Split(providerID[len(prefix):], "/")
 	instanceID := parts[1]
 
-	klog.Infof("Instance ID `%s` extracted from provider `%s`", instanceID, providerID)
+	klog.V(8).Infof("Instance ID `%s` extracted from provider `%s`", instanceID, providerID)
 	return instanceID, nil
 }


### PR DESCRIPTION
Remove the forceRefresh in GetGroupForInstance

During the initialization, CA needs to get the group id for each instance; but in our case most of the instances (300+ search replica instances) are not under the given elastigroup, so it will waste a lot of time on this forceRefresh.